### PR TITLE
Feat: Adiciona exceção para builds locais

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
-
+# Build dependencies
+node_modules


### PR DESCRIPTION
Desculpe pela confusão! Aqui está a descrição do commit com os snippets de código em texto simples:

- A biblioteca BCrypt apresenta problemas de build entre diferentes sistemas operacionais (macOS, Windows e Linux). Para mais informações, consulte o link do Stack Overflow.
- Para evitar comportamentos indesejados no build local, incluí a flag `node_modules` no `.dockerignore`, impedindo a cópia dos recursos da máquina local.
- No entanto, isso gerou problemas de build com o Babel. Portanto, adicionei a seguinte linha ao Dockerfile: RUN npm install @babel/plugin-proposal-decorators @babel/plugin-proposal-class-properties
- Essa instalação permite o reconhecimento de decorators, como os do TypeORM e NestJS. RUN npm install -g @nestjs/cli
- Este comando é necessário para o build no GitHub Actions, pois ele não reconhece a instalação local do CLI do NestJS após a instalação do Babel. Essa configuração garante a interoperabilidade entre as ações e o build local, visando abranger o máximo de ambientes possíveis.