### PR TITLE
fix: Update 'UserSchoolAssociation' references to 'Association'.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ async function bootstrap() {
     .setDescription('API para criação de posts')
     .setVersion('1.0')
     .addTag('Post')
-    .addTag('UserSchoolAssociation')
+    .addTag('Association')
     .addTag('User')
     .addTag('School')
     .addTag('Auth')

--- a/src/user-school-association/controllers/association.controller.ts
+++ b/src/user-school-association/controllers/association.controller.ts
@@ -30,7 +30,7 @@ import TokenProvider from '@/Utils/InviteToken';
 import ValidToken from '@/Utils/validToken';
 import { env } from '@/env';
 import { GlobalTokenService } from '@/shared/globalTokenService';
-@ApiTags('UserSchoolAssociation')
+@ApiTags('Association')
 @UseGuards(AuthGuard)
 @Controller('association')
 export class UserSchoolAssociationController {


### PR DESCRIPTION
- Update tag from 'UserSchoolAssociation' to 'Association' in app description and tags.
- Updated API tags from 'UserSchoolAssociation' to 'Association' in UserSchoolAssociationController to better reflect the main focus.